### PR TITLE
Starting Equipment Fixes

### DIFF
--- a/app/Rom.php
+++ b/app/Rom.php
@@ -267,10 +267,14 @@ class Rom {
 					break;
 				case 'SilverArrowUpgrade':
 					$equipment[0x38E] |= 0b01000000;
+					if ($this->config('rom.rupeeBow', true))
+						$equipment[0x377] = 0x01;
 					break;
 				case 'BowAndSilverArrows':
 					$equipment[0x340] = 0x04;
 					$equipment[0x38E] |= 0b01000000;
+					if ($this->config('rom.rupeeBow', true))
+						$equipment[0x377] = 0x01;
 					break;
 				case 'Boomerang':
 					$equipment[0x341] = 0x01;
@@ -283,6 +287,7 @@ class Rom {
 				case 'Mushroom':
 					$equipment[0x344] = 0x01;
 					$equipment[0x38C] |= 0b00100000;
+					$equipment[0x38C] |= 0b00001000;
 					break;
 				case 'Powder':
 					$equipment[0x344] = 0x02;


### PR DESCRIPTION
Used the empty bit in INVENTORY_SWAP to add a toggle for mushroom in past, consistent with my pull request to /z3randomizer
Moving the rupee bow starting equipment silver arrows fix from /z3randomizer/events.asm here, since it sort of belongs here.